### PR TITLE
Add Concepts section — non-technical onboarding pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@konoss/app-dashboard",
+  "name": "@kontango/site",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@konoss/app-dashboard",
+      "name": "@kontango/site",
       "version": "1.0.0",
       "dependencies": {
         "framer-motion": "^12.23.26",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { Hardware } from './pages/Hardware'
 import { About } from './pages/About'
 import { Contact } from './pages/Contact'
 import { Docs } from './pages/Docs'
+import { Concepts } from './pages/Concepts'
+import { ConceptArticle } from './pages/ConceptArticle'
 
 function App() {
   return (
@@ -19,6 +21,8 @@ function App() {
         <Route path="/about" element={<About />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/docs" element={<Docs />} />
+        <Route path="/concepts" element={<Concepts />} />
+        <Route path="/concepts/:slug" element={<ConceptArticle />} />
       </Routes>
     </Layout>
   )

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -57,6 +57,7 @@ export function Navbar() {
 
   const navLinks = [
     { path: '/', label: 'Home' },
+    { path: '/concepts', label: 'Concepts' },
     { path: '/guide', label: 'Guide' },
     { path: '/hardware', label: 'Hardware' },
     { path: '/about', label: 'About' },

--- a/src/content/concepts.ts
+++ b/src/content/concepts.ts
@@ -1,0 +1,106 @@
+// Concepts metadata — maps slugs to titles, descriptions, and profile fit.
+// Markdown content is fetched from KontangoOSS/docs/concepts/<slug>.md
+// (and <slug>-short.md for the quick version, when present).
+
+export type ConceptProfile = 'newcomer' | 'operator' | 'business'
+
+export interface Concept {
+  slug: string
+  number: string
+  title: string
+  description: string
+  /** Audiences this concept is most useful for. Used by the profile selector. */
+  profiles: ConceptProfile[]
+  /** Reading time for the full version. */
+  timeEstimate: string
+}
+
+export const concepts: Concept[] = [
+  {
+    slug: 'what-is-kontango',
+    number: '01',
+    title: 'What is Kontango?',
+    description: 'One paragraph, two paragraphs, and three real things you can do with it.',
+    profiles: ['newcomer', 'business', 'operator'],
+    timeEstimate: '4 min',
+  },
+  {
+    slug: 'the-network',
+    number: '02',
+    title: 'The Network',
+    description: 'What "the Kontango network" means — and what it isn\'t. Hardware freedom is the point.',
+    profiles: ['newcomer', 'operator'],
+    timeEstimate: '5 min',
+  },
+  {
+    slug: 'enrollment',
+    number: '03',
+    title: 'Enrolling a Device',
+    description: 'What happens when you add a laptop. What gets sent, what stays put, and why the wait.',
+    profiles: ['newcomer', 'operator'],
+    timeEstimate: '5 min',
+  },
+  {
+    slug: 'identities',
+    number: '04',
+    title: 'Identities',
+    description: 'What "identity" means for a device, a server, or a service that talks to other services.',
+    profiles: ['operator'],
+    timeEstimate: '4 min',
+  },
+  {
+    slug: 'services',
+    number: '05',
+    title: 'Services',
+    description: 'What you actually connect to on the network — git, secrets, dashboards, all on your hardware.',
+    profiles: ['newcomer', 'business', 'operator'],
+    timeEstimate: '4 min',
+  },
+  {
+    slug: 'policy',
+    number: '06',
+    title: 'Policy',
+    description: 'Who is allowed to talk to what. The rules that gate every connection on the network.',
+    profiles: ['operator'],
+    timeEstimate: '5 min',
+  },
+  {
+    slug: 'when-things-break',
+    number: '07',
+    title: 'When Things Break',
+    description: 'Symptoms you might see, what each one means, and what to try before asking for help.',
+    profiles: ['newcomer', 'operator'],
+    timeEstimate: '5 min',
+  },
+  {
+    slug: 'getting-help',
+    number: '08',
+    title: 'Getting Help',
+    description: 'Email, Discord, paid support. Open source with help available.',
+    profiles: ['newcomer', 'business', 'operator'],
+    timeEstimate: '3 min',
+  },
+]
+
+export function getConceptBySlug(slug: string): Concept | undefined {
+  return concepts.find(c => c.slug === slug)
+}
+
+export function conceptsForProfile(profile: ConceptProfile): Concept[] {
+  return concepts.filter(c => c.profiles.includes(profile))
+}
+
+export const profileLabels: Record<ConceptProfile, { name: string; tagline: string }> = {
+  newcomer: {
+    name: 'New here',
+    tagline: "I'm not technical — show me the short version",
+  },
+  business: {
+    name: 'Decision maker',
+    tagline: 'I want to understand what this is and what it costs',
+  },
+  operator: {
+    name: 'Running it',
+    tagline: 'I operate the platform — give me the full text',
+  },
+}

--- a/src/pages/ConceptArticle.tsx
+++ b/src/pages/ConceptArticle.tsx
@@ -1,0 +1,215 @@
+import { CSSProperties, useEffect, useState } from 'react'
+import { useParams, useSearchParams, Link } from 'react-router-dom'
+import { theme } from '../styles/theme'
+import { Container } from '../components/ui/Container'
+import { Button } from '../components/ui/Button'
+import { MarkdownContent } from '../components/ui/MarkdownContent'
+import { concepts, getConceptBySlug } from '../content/concepts'
+
+const DOCS_BASE = 'https://raw.githubusercontent.com/KontangoOSS/docs/main/concepts'
+
+type Variant = 'short' | 'full'
+
+export function ConceptArticle() {
+  const { slug } = useParams<{ slug: string }>()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [content, setContent] = useState<string>('')
+  const [loading, setLoading] = useState(true)
+  const [shortAvailable, setShortAvailable] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
+  const concept = slug ? getConceptBySlug(slug) : undefined
+
+  // Variant comes from ?v=short — defaults to full.
+  const variant: Variant = searchParams.get('v') === 'short' ? 'short' : 'full'
+
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth < 768)
+    checkMobile()
+    window.addEventListener('resize', checkMobile)
+    return () => window.removeEventListener('resize', checkMobile)
+  }, [])
+
+  useEffect(() => {
+    if (!slug) return
+    setLoading(true)
+
+    async function loadContent() {
+      const fileName = variant === 'short' ? `${slug}-short` : slug
+      const fallback = `${slug}` // if -short doesn't exist, fall through to long
+
+      try {
+        const res = await fetch(`${DOCS_BASE}/${fileName}.md`)
+        if (res.ok) {
+          setContent(await res.text())
+          if (variant === 'full') {
+            // Also probe whether a -short.md exists, so we can show the toggle
+            const probe = await fetch(`${DOCS_BASE}/${slug}-short.md`, { method: 'HEAD' })
+            setShortAvailable(probe.ok)
+          } else {
+            setShortAvailable(true)
+          }
+        } else if (variant === 'short') {
+          // No short version yet — fall back to full and tell the toggle
+          const fullRes = await fetch(`${DOCS_BASE}/${fallback}.md`)
+          if (fullRes.ok) {
+            setContent(await fullRes.text())
+          } else {
+            setContent(`# ${concept?.title ?? 'Concept'}\n\nContent coming soon. View on [GitHub](https://github.com/KontangoOSS/docs/tree/main/concepts).`)
+          }
+          setShortAvailable(false)
+        } else {
+          setContent(`# ${concept?.title ?? 'Concept'}\n\nContent coming soon. View on [GitHub](https://github.com/KontangoOSS/docs/tree/main/concepts).`)
+        }
+      } catch {
+        setContent(`# ${concept?.title ?? 'Concept'}\n\nCouldn't load this page. Try refreshing or view it on [GitHub](https://github.com/KontangoOSS/docs/tree/main/concepts).`)
+      }
+
+      setLoading(false)
+    }
+
+    loadContent()
+  }, [slug, variant, concept?.title])
+
+  const currentIndex = concepts.findIndex(c => c.slug === slug)
+  const prev = currentIndex > 0 ? concepts[currentIndex - 1] : undefined
+  const next = currentIndex < concepts.length - 1 ? concepts[currentIndex + 1] : undefined
+
+  const headerStyle: CSSProperties = {
+    paddingTop: theme.spacing.xxxl,
+    paddingBottom: theme.spacing.xl,
+    borderBottom: `1px solid ${theme.colors.border}`,
+    marginBottom: theme.spacing.xl,
+  }
+
+  const navStyle: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+    gap: theme.spacing.lg,
+    marginTop: theme.spacing.xxxl,
+    paddingTop: theme.spacing.xl,
+    borderTop: `1px solid ${theme.colors.border}`,
+  }
+
+  const navCardStyle: CSSProperties = {
+    padding: theme.spacing.lg,
+    background: theme.colors.surface,
+    border: `1px solid ${theme.colors.border}`,
+    borderRadius: theme.borderRadius.md,
+    textDecoration: 'none',
+  }
+
+  const toggleStyle = (active: boolean): CSSProperties => ({
+    padding: `${theme.spacing.xs} ${theme.spacing.md}`,
+    background: active ? theme.colors.primary : 'transparent',
+    color: active ? '#0a0a0f' : theme.colors.textSecondary,
+    border: `1px solid ${active ? theme.colors.primary : theme.colors.border}`,
+    borderRadius: theme.borderRadius.full,
+    cursor: 'pointer',
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    transition: 'all 0.15s ease',
+  })
+
+  if (!concept) {
+    return (
+      <Container>
+        <div style={{ textAlign: 'center', paddingTop: theme.spacing.xxxl }}>
+          <h1>Concept Not Found</h1>
+          <Button variant="primary" href="/concepts">Back to Concepts</Button>
+        </div>
+      </Container>
+    )
+  }
+
+  return (
+    <Container size="md">
+      <header style={headerStyle}>
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.sm,
+          marginBottom: theme.spacing.lg,
+          fontSize: theme.fontSize.sm,
+          color: theme.colors.textMuted,
+        }}>
+          <Link to="/" style={{ color: theme.colors.textMuted, textDecoration: 'none' }}>Home</Link>
+          <span>/</span>
+          <Link to="/concepts" style={{ color: theme.colors.textMuted, textDecoration: 'none' }}>Concepts</Link>
+          <span>/</span>
+          <span style={{ color: theme.colors.textSecondary }}>{concept.number}</span>
+        </div>
+
+        <h1 style={{
+          fontSize: theme.fontSize['4xl'],
+          fontWeight: theme.fontWeight.bold,
+          color: theme.colors.textPrimary,
+          marginBottom: theme.spacing.sm,
+        }}>
+          {concept.title}
+        </h1>
+        <p style={{ fontSize: theme.fontSize.lg, color: theme.colors.textSecondary, lineHeight: 1.6 }}>
+          {concept.description}
+        </p>
+
+        <div style={{
+          marginTop: theme.spacing.lg,
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.md,
+          flexWrap: 'wrap',
+        }}>
+          {shortAvailable && (
+            <div style={{ display: 'flex', gap: theme.spacing.xs }}>
+              <button
+                style={toggleStyle(variant === 'short')}
+                onClick={() => setSearchParams({ v: 'short' })}
+              >
+                Quick version
+              </button>
+              <button
+                style={toggleStyle(variant === 'full')}
+                onClick={() => setSearchParams({})}
+              >
+                Full version
+              </button>
+            </div>
+          )}
+          <div style={{ fontSize: theme.fontSize.sm, color: theme.colors.textMuted }}>
+            ⏱️ {variant === 'short' ? '~1 min' : concept.timeEstimate}
+          </div>
+        </div>
+      </header>
+
+      {loading ? (
+        <div style={{ textAlign: 'center', padding: theme.spacing.xxl, color: theme.colors.textSecondary }}>
+          Loading…
+        </div>
+      ) : (
+        <MarkdownContent content={content} />
+      )}
+
+      <nav style={navStyle}>
+        {prev ? (
+          <Link to={`/concepts/${prev.slug}`} style={navCardStyle}>
+            <div style={{ fontSize: theme.fontSize.xs, color: theme.colors.textMuted, marginBottom: theme.spacing.xs }}>← Previous</div>
+            <div style={{ fontSize: theme.fontSize.base, color: theme.colors.textPrimary, fontWeight: theme.fontWeight.medium }}>
+              {prev.number}. {prev.title}
+            </div>
+          </Link>
+        ) : <div />}
+        {next ? (
+          <Link to={`/concepts/${next.slug}`} style={{ ...navCardStyle, textAlign: 'right' }}>
+            <div style={{ fontSize: theme.fontSize.xs, color: theme.colors.textMuted, marginBottom: theme.spacing.xs }}>Next →</div>
+            <div style={{ fontSize: theme.fontSize.base, color: theme.colors.textPrimary, fontWeight: theme.fontWeight.medium }}>
+              {next.number}. {next.title}
+            </div>
+          </Link>
+        ) : <div />}
+      </nav>
+
+      <div style={{ marginTop: theme.spacing.xxl, marginBottom: theme.spacing.xxxl, textAlign: 'center' }}>
+        <Button variant="outline" href="/concepts">← Back to all concepts</Button>
+      </div>
+    </Container>
+  )
+}

--- a/src/pages/Concepts.tsx
+++ b/src/pages/Concepts.tsx
@@ -1,0 +1,205 @@
+import { CSSProperties, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { theme } from '../styles/theme'
+import { Container } from '../components/ui/Container'
+import { concepts, ConceptProfile, profileLabels } from '../content/concepts'
+
+export function Concepts() {
+  const [profile, setProfile] = useState<ConceptProfile | 'all'>('all')
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth < 768)
+    checkMobile()
+    window.addEventListener('resize', checkMobile)
+    return () => window.removeEventListener('resize', checkMobile)
+  }, [])
+
+  const visible = profile === 'all'
+    ? concepts
+    : concepts.filter(c => c.profiles.includes(profile))
+
+  // Newcomers default to short. Operators default to full.
+  const linkFor = (slug: string) => {
+    if (profile === 'newcomer') return `/concepts/${slug}?v=short`
+    return `/concepts/${slug}`
+  }
+
+  const heroStyle: CSSProperties = {
+    paddingTop: theme.spacing.xxxl,
+    paddingBottom: theme.spacing.xxl,
+    textAlign: 'center',
+  }
+
+  const profileGrid: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)',
+    gap: theme.spacing.md,
+    maxWidth: '880px',
+    margin: '0 auto',
+    marginBottom: theme.spacing.xxl,
+  }
+
+  const profileCard = (active: boolean): CSSProperties => ({
+    padding: theme.spacing.lg,
+    background: active ? 'rgba(74, 158, 255, 0.08)' : theme.colors.surface,
+    border: `1px solid ${active ? theme.colors.primary : theme.colors.border}`,
+    borderRadius: theme.borderRadius.lg,
+    cursor: 'pointer',
+    textAlign: 'left',
+    transition: 'all 0.15s ease',
+    color: theme.colors.textPrimary,
+    fontFamily: 'inherit',
+    width: '100%',
+  })
+
+  const conceptGrid: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: isMobile ? '1fr' : 'repeat(2, 1fr)',
+    gap: theme.spacing.lg,
+    marginTop: theme.spacing.xl,
+    marginBottom: theme.spacing.xxxl,
+  }
+
+  const conceptCardStyle: CSSProperties = {
+    display: 'block',
+    padding: theme.spacing.xl,
+    background: theme.colors.surface,
+    border: `1px solid ${theme.colors.border}`,
+    borderRadius: theme.borderRadius.lg,
+    textDecoration: 'none',
+    transition: 'all 0.15s ease',
+  }
+
+  return (
+    <Container size="lg">
+      <section style={heroStyle}>
+        <h1 style={{
+          fontSize: isMobile ? theme.fontSize['3xl'] : theme.fontSize['5xl'],
+          fontWeight: theme.fontWeight.bold,
+          color: theme.colors.textPrimary,
+          marginBottom: theme.spacing.md,
+          lineHeight: 1.1,
+        }}>
+          Core Concepts
+        </h1>
+        <p style={{
+          fontSize: isMobile ? theme.fontSize.base : theme.fontSize.xl,
+          color: theme.colors.textSecondary,
+          maxWidth: '720px',
+          margin: '0 auto',
+          lineHeight: 1.6,
+        }}>
+          Eight short pages that explain Kontango in plain language. Pick the angle that fits — we'll show you the version that makes sense for you.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: theme.spacing.xl }}>
+        <div style={{
+          fontSize: theme.fontSize.sm,
+          color: theme.colors.textMuted,
+          textAlign: 'center',
+          marginBottom: theme.spacing.md,
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+        }}>
+          Choose your view
+        </div>
+        <div style={profileGrid}>
+          {(['newcomer', 'business', 'operator'] as ConceptProfile[]).map(p => (
+            <button
+              key={p}
+              style={profileCard(profile === p)}
+              onClick={() => setProfile(profile === p ? 'all' : p)}
+            >
+              <div style={{
+                fontSize: theme.fontSize.base,
+                fontWeight: theme.fontWeight.bold,
+                color: profile === p ? theme.colors.primary : theme.colors.textPrimary,
+                marginBottom: theme.spacing.xs,
+              }}>
+                {profileLabels[p].name}
+              </div>
+              <div style={{
+                fontSize: theme.fontSize.sm,
+                color: theme.colors.textSecondary,
+                lineHeight: 1.5,
+              }}>
+                {profileLabels[p].tagline}
+              </div>
+            </button>
+          ))}
+        </div>
+        {profile !== 'all' && (
+          <div style={{ textAlign: 'center', fontSize: theme.fontSize.sm, color: theme.colors.textMuted }}>
+            Showing concepts most useful for: <strong style={{ color: theme.colors.textSecondary }}>{profileLabels[profile].name}</strong>
+            {' · '}
+            <button
+              style={{
+                background: 'none',
+                border: 'none',
+                color: theme.colors.primary,
+                cursor: 'pointer',
+                fontSize: 'inherit',
+                padding: 0,
+                fontFamily: 'inherit',
+              }}
+              onClick={() => setProfile('all')}
+            >
+              Show all
+            </button>
+          </div>
+        )}
+      </section>
+
+      <section style={conceptGrid}>
+        {visible.map(c => (
+          <Link key={c.slug} to={linkFor(c.slug)} style={conceptCardStyle}>
+            <div style={{
+              fontSize: theme.fontSize.xs,
+              color: theme.colors.primary,
+              fontWeight: theme.fontWeight.bold,
+              marginBottom: theme.spacing.xs,
+              letterSpacing: '0.05em',
+            }}>
+              {c.number}
+            </div>
+            <h3 style={{
+              fontSize: theme.fontSize.xl,
+              fontWeight: theme.fontWeight.semibold,
+              color: theme.colors.textPrimary,
+              marginBottom: theme.spacing.sm,
+            }}>
+              {c.title}
+            </h3>
+            <p style={{
+              fontSize: theme.fontSize.base,
+              color: theme.colors.textSecondary,
+              lineHeight: 1.6,
+              marginBottom: theme.spacing.md,
+            }}>
+              {c.description}
+            </p>
+            <div style={{ fontSize: theme.fontSize.xs, color: theme.colors.textMuted }}>
+              {profile === 'newcomer' ? 'Quick version · ~1 min' : `⏱️ ${c.timeEstimate}`}
+            </div>
+          </Link>
+        ))}
+      </section>
+
+      <section style={{ textAlign: 'center', marginBottom: theme.spacing.xxxl }}>
+        <p style={{ color: theme.colors.textSecondary, marginBottom: theme.spacing.md }}>
+          Ready to go deeper?
+        </p>
+        <Link to="/guide" style={{
+          color: theme.colors.primary,
+          textDecoration: 'none',
+          fontSize: theme.fontSize.base,
+          fontWeight: theme.fontWeight.medium,
+        }}>
+          Read the Self-Hosting Guide →
+        </Link>
+      </section>
+    </Container>
+  )
+}


### PR DESCRIPTION
## Summary

Renders the 8 core concept pages (already in `KontangoOSS/docs/concepts/*.md`) inside the marketing site — same theme, same palette, same chrome.

## Why this approach

We tried hosting docs at `kontangooss.github.io/docs` with Hugo + Relearn. It works, but feels like developer documentation rather than the product-quality experience non-technical visitors deserve. The marketing site already has the right look and the right tools (`react-markdown`, the existing `MarkdownContent` component, route-based markdown fetching from raw.githubusercontent.com). One source of truth, one rendered site.

## What's in the PR

- `src/content/concepts.ts` — concept metadata + profile mapping (newcomer / business / operator)
- `src/pages/Concepts.tsx` — landing page with profile selector and concept cards
- `src/pages/ConceptArticle.tsx` — individual concept with quick/full toggle, prev/next navigation
- `src/App.tsx` — adds `/concepts` and `/concepts/:slug` routes
- `src/components/layout/Navbar.tsx` — adds Concepts to the top nav

## How profiles work

The `/concepts` page shows three profile cards. Clicking one filters the concept cards to those most relevant for that audience and changes the link target so newcomers go to `?v=short`. The article page reads the variant from the URL query, fetches `<slug>-short.md` if requested, and gracefully falls back to the full text when a short version doesn't exist yet.

## Status of the short variants

The `-short.md` files **don't exist yet** — that ships in #2. Right now the toggle is hidden when no short version is found, so the full markdown reads cleanly. Once we write the shorts in the docs repo, no PR to the site is needed; the toggle appears automatically.

## Test plan

- [ ] Build succeeds locally (`npm run build` — done, 1.27s)
- [ ] Visit `/concepts` → profile selector renders, all 8 cards visible
- [ ] Pick "New here" → cards filter, link target changes to `?v=short`
- [ ] Click any concept → markdown loads from raw.githubusercontent.com
- [ ] Prev/next navigation works in concept order
- [ ] Mobile (< 768px) collapses to single column

Closes #1
Refs #2