### PR TITLE
Fix SPA 404 fallback — direct URLs to /concepts, /guide, etc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run build
+      - name: SPA fallback — copy index.html to 404.html
+        run: cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist


### PR DESCRIPTION
## Summary

Adds a one-line workflow step that copies `dist/index.html` to `dist/404.html` after the Vite build, so GitHub Pages serves the SPA shell for unknown paths instead of its default 404.

## Why

After PR #3 shipped Concepts, every direct hit on `/concepts`, `/concepts/:slug`, and any other client-side route returned HTTP 404. Verified pre-existing for `/guide`, `/about`, `/hardware` too — this is a pre-existing site bug, not caused by #3.

GitHub Pages is a static host. Without a `404.html`, it returns its own 404 page instead of letting the SPA handle the route. With one, it serves that file for any unknown path; React Router boots from there and resolves the URL on the client.

## Test plan

- [ ] Build runs the new step
- [ ] After deploy, `/concepts` returns 200 with the SPA loaded
- [ ] `/concepts/what-is-kontango` returns 200 and renders the markdown
- [ ] `/guide`, `/about`, `/hardware` return 200 (regression fix)
- [ ] `/` still works as before

Closes #4