### PR TITLE
Fix BrowserRouter basename — restore routing under /site/ prefix

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </StrictMode>


### PR DESCRIPTION
## Summary

One-line fix: pass `basename={import.meta.env.BASE_URL}` to `<BrowserRouter>`.

## Why

After PR #5 fixed the SPA fallback, direct URLs returned the SPA shell — but the **content area was empty**, because React Router was trying to match `/site/concepts` against routes defined as `/concepts`. `No routes matched location "/site/concepts"` in the console.

The homepage worked by coincidence (empty path after `/site` matched `/`). Every other route hit the empty fallback.

## Fix

```tsx
<BrowserRouter basename={import.meta.env.BASE_URL}>
```

`import.meta.env.BASE_URL` mirrors Vite's `base` config, so this works in dev (`/`) and prod (`/site/`) without hardcoding.

## Test plan

- [ ] Build passes (verified locally — 1.38s)
- [ ] After deploy, `/site/concepts` renders the Concepts landing page (not empty)
- [ ] `/site/concepts/what-is-kontango` renders the article with markdown loaded
- [ ] `/site/guide`, `/site/about`, `/site/hardware` all render their pages (regression fix)
- [ ] No console warnings about unmatched routes

Closes #6