### PR TITLE
Three-tier concept variants — Quick / Standard / Deep

### DIFF
--- a/src/content/concepts.ts
+++ b/src/content/concepts.ts
@@ -1,17 +1,22 @@
 // Concepts metadata — maps slugs to titles, descriptions, and profile fit.
-// Markdown content is fetched from KontangoOSS/docs/concepts/<slug>.md
-// (and <slug>-short.md for the quick version, when present).
+// Markdown content is fetched from KontangoOSS/docs/concepts/<slug><variant-suffix>.md
+//
+// Three tiers per concept:
+//   short  → <slug>-short.md  — ~150 words, plain language
+//   medium → <slug>.md         — the standard read
+//   long   → <slug>-long.md    — operator/architecture detail
 
-export type ConceptProfile = 'newcomer' | 'operator' | 'business'
+export type ConceptVariant = 'short' | 'medium' | 'long'
+export type ConceptProfile = 'newcomer' | 'business' | 'operator'
 
 export interface Concept {
   slug: string
   number: string
   title: string
   description: string
-  /** Audiences this concept is most useful for. Used by the profile selector. */
+  /** Audiences this concept is most useful for. */
   profiles: ConceptProfile[]
-  /** Reading time for the full version. */
+  /** Reading time for the medium version. */
   timeEstimate: string
 }
 
@@ -86,21 +91,36 @@ export function getConceptBySlug(slug: string): Concept | undefined {
   return concepts.find(c => c.slug === slug)
 }
 
-export function conceptsForProfile(profile: ConceptProfile): Concept[] {
-  return concepts.filter(c => c.profiles.includes(profile))
-}
-
-export const profileLabels: Record<ConceptProfile, { name: string; tagline: string }> = {
+export const profileLabels: Record<ConceptProfile, { name: string; tagline: string; defaultVariant: ConceptVariant; tierColor: string }> = {
   newcomer: {
     name: 'New here',
-    tagline: "I'm not technical — show me the short version",
+    tagline: "Plain language. Show me the short version.",
+    defaultVariant: 'short',
+    tierColor: '#51cf66', // theme.colors.basic
   },
   business: {
     name: 'Decision maker',
-    tagline: 'I want to understand what this is and what it costs',
+    tagline: 'I want to understand what this is and what it costs.',
+    defaultVariant: 'medium',
+    tierColor: '#ffd43b', // theme.colors.intermediate
   },
   operator: {
     name: 'Running it',
-    tagline: 'I operate the platform — give me the full text',
+    tagline: 'I operate the platform. Give me the full text.',
+    defaultVariant: 'long',
+    tierColor: '#4a9eff', // theme.colors.enterprise
   },
+}
+
+export const variantLabels: Record<ConceptVariant, { label: string; estimate: (base: string) => string }> = {
+  short:  { label: 'Quick',   estimate: () => '~1 min' },
+  medium: { label: 'Standard', estimate: base => base },
+  long:   { label: 'Deep',    estimate: base => `~${parseInt(base) * 2} min` },
+}
+
+/** Returns the markdown URL path suffix for a given variant. */
+export function fileSuffix(variant: ConceptVariant): string {
+  if (variant === 'short') return '-short'
+  if (variant === 'long') return '-long'
+  return ''
 }

--- a/src/pages/ConceptArticle.tsx
+++ b/src/pages/ConceptArticle.tsx
@@ -4,23 +4,37 @@ import { theme } from '../styles/theme'
 import { Container } from '../components/ui/Container'
 import { Button } from '../components/ui/Button'
 import { MarkdownContent } from '../components/ui/MarkdownContent'
-import { concepts, getConceptBySlug } from '../content/concepts'
+import {
+  concepts,
+  getConceptBySlug,
+  ConceptVariant,
+  variantLabels,
+  fileSuffix,
+} from '../content/concepts'
 
 const DOCS_BASE = 'https://raw.githubusercontent.com/KontangoOSS/docs/main/concepts'
 
-type Variant = 'short' | 'full'
+const variantOrder: ConceptVariant[] = ['short', 'medium', 'long']
+
+function parseVariant(v: string | null): ConceptVariant {
+  if (v === 'short' || v === 'long') return v
+  return 'medium'
+}
+
+const tierColor: Record<ConceptVariant, string> = {
+  short: theme.colors.basic,
+  medium: theme.colors.intermediate,
+  long: theme.colors.enterprise,
+}
 
 export function ConceptArticle() {
   const { slug } = useParams<{ slug: string }>()
   const [searchParams, setSearchParams] = useSearchParams()
   const [content, setContent] = useState<string>('')
   const [loading, setLoading] = useState(true)
-  const [shortAvailable, setShortAvailable] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
   const concept = slug ? getConceptBySlug(slug) : undefined
-
-  // Variant comes from ?v=short — defaults to full.
-  const variant: Variant = searchParams.get('v') === 'short' ? 'short' : 'full'
+  const variant = parseVariant(searchParams.get('v'))
 
   useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth < 768)
@@ -34,41 +48,36 @@ export function ConceptArticle() {
     setLoading(true)
 
     async function loadContent() {
-      const fileName = variant === 'short' ? `${slug}-short` : slug
-      const fallback = `${slug}` // if -short doesn't exist, fall through to long
-
+      const path = `${slug}${fileSuffix(variant)}.md`
       try {
-        const res = await fetch(`${DOCS_BASE}/${fileName}.md`)
+        const res = await fetch(`${DOCS_BASE}/${path}`)
         if (res.ok) {
           setContent(await res.text())
-          if (variant === 'full') {
-            // Also probe whether a -short.md exists, so we can show the toggle
-            const probe = await fetch(`${DOCS_BASE}/${slug}-short.md`, { method: 'HEAD' })
-            setShortAvailable(probe.ok)
+        } else if (variant !== 'medium') {
+          // Fall back to medium if a tier doesn't exist yet
+          const fallback = await fetch(`${DOCS_BASE}/${slug}.md`)
+          if (fallback.ok) {
+            setContent(await fallback.text())
           } else {
-            setShortAvailable(true)
+            setContent(`# ${concept?.title ?? 'Concept'}\n\nContent coming soon.`)
           }
-        } else if (variant === 'short') {
-          // No short version yet — fall back to full and tell the toggle
-          const fullRes = await fetch(`${DOCS_BASE}/${fallback}.md`)
-          if (fullRes.ok) {
-            setContent(await fullRes.text())
-          } else {
-            setContent(`# ${concept?.title ?? 'Concept'}\n\nContent coming soon. View on [GitHub](https://github.com/KontangoOSS/docs/tree/main/concepts).`)
-          }
-          setShortAvailable(false)
         } else {
-          setContent(`# ${concept?.title ?? 'Concept'}\n\nContent coming soon. View on [GitHub](https://github.com/KontangoOSS/docs/tree/main/concepts).`)
+          setContent(`# ${concept?.title ?? 'Concept'}\n\nContent coming soon.`)
         }
       } catch {
-        setContent(`# ${concept?.title ?? 'Concept'}\n\nCouldn't load this page. Try refreshing or view it on [GitHub](https://github.com/KontangoOSS/docs/tree/main/concepts).`)
+        setContent(`# ${concept?.title ?? 'Concept'}\n\nCouldn't load this page. Try refreshing.`)
       }
-
       setLoading(false)
     }
 
     loadContent()
+    window.scrollTo({ top: 0, behavior: 'instant' })
   }, [slug, variant, concept?.title])
+
+  const setVariant = (v: ConceptVariant) => {
+    if (v === 'medium') setSearchParams({})
+    else setSearchParams({ v })
+  }
 
   const currentIndex = concepts.findIndex(c => c.slug === slug)
   const prev = currentIndex > 0 ? concepts[currentIndex - 1] : undefined
@@ -98,16 +107,18 @@ export function ConceptArticle() {
     textDecoration: 'none',
   }
 
-  const toggleStyle = (active: boolean): CSSProperties => ({
+  // Tier toggle — three pill buttons with the tier color when active
+  const pillStyle = (v: ConceptVariant, active: boolean): CSSProperties => ({
     padding: `${theme.spacing.xs} ${theme.spacing.md}`,
-    background: active ? theme.colors.primary : 'transparent',
+    background: active ? tierColor[v] : 'transparent',
     color: active ? '#0a0a0f' : theme.colors.textSecondary,
-    border: `1px solid ${active ? theme.colors.primary : theme.colors.border}`,
+    border: `1px solid ${active ? tierColor[v] : theme.colors.border}`,
     borderRadius: theme.borderRadius.full,
     cursor: 'pointer',
     fontSize: theme.fontSize.sm,
     fontWeight: theme.fontWeight.medium,
     transition: 'all 0.15s ease',
+    fontFamily: 'inherit',
   })
 
   if (!concept) {
@@ -158,24 +169,28 @@ export function ConceptArticle() {
           gap: theme.spacing.md,
           flexWrap: 'wrap',
         }}>
-          {shortAvailable && (
-            <div style={{ display: 'flex', gap: theme.spacing.xs }}>
+          <div style={{
+            display: 'flex',
+            gap: theme.spacing.xs,
+            padding: theme.spacing.xs,
+            background: theme.colors.surface,
+            borderRadius: theme.borderRadius.full,
+            border: `1px solid ${theme.colors.border}`,
+          }}>
+            {variantOrder.map(v => (
               <button
-                style={toggleStyle(variant === 'short')}
-                onClick={() => setSearchParams({ v: 'short' })}
+                key={v}
+                style={pillStyle(v, variant === v)}
+                onClick={() => setVariant(v)}
+                aria-pressed={variant === v}
+                aria-label={`Switch to ${variantLabels[v].label} version`}
               >
-                Quick version
+                {variantLabels[v].label}
               </button>
-              <button
-                style={toggleStyle(variant === 'full')}
-                onClick={() => setSearchParams({})}
-              >
-                Full version
-              </button>
-            </div>
-          )}
+            ))}
+          </div>
           <div style={{ fontSize: theme.fontSize.sm, color: theme.colors.textMuted }}>
-            ⏱️ {variant === 'short' ? '~1 min' : concept.timeEstimate}
+            ⏱️ {variantLabels[variant].estimate(concept.timeEstimate)}
           </div>
         </div>
       </header>
@@ -190,7 +205,10 @@ export function ConceptArticle() {
 
       <nav style={navStyle}>
         {prev ? (
-          <Link to={`/concepts/${prev.slug}`} style={navCardStyle}>
+          <Link
+            to={`/concepts/${prev.slug}${variant !== 'medium' ? `?v=${variant}` : ''}`}
+            style={navCardStyle}
+          >
             <div style={{ fontSize: theme.fontSize.xs, color: theme.colors.textMuted, marginBottom: theme.spacing.xs }}>← Previous</div>
             <div style={{ fontSize: theme.fontSize.base, color: theme.colors.textPrimary, fontWeight: theme.fontWeight.medium }}>
               {prev.number}. {prev.title}
@@ -198,7 +216,10 @@ export function ConceptArticle() {
           </Link>
         ) : <div />}
         {next ? (
-          <Link to={`/concepts/${next.slug}`} style={{ ...navCardStyle, textAlign: 'right' }}>
+          <Link
+            to={`/concepts/${next.slug}${variant !== 'medium' ? `?v=${variant}` : ''}`}
+            style={{ ...navCardStyle, textAlign: 'right' }}
+          >
             <div style={{ fontSize: theme.fontSize.xs, color: theme.colors.textMuted, marginBottom: theme.spacing.xs }}>Next →</div>
             <div style={{ fontSize: theme.fontSize.base, color: theme.colors.textPrimary, fontWeight: theme.fontWeight.medium }}>
               {next.number}. {next.title}

--- a/src/pages/Concepts.tsx
+++ b/src/pages/Concepts.tsx
@@ -4,8 +4,17 @@ import { theme } from '../styles/theme'
 import { Container } from '../components/ui/Container'
 import { concepts, ConceptProfile, profileLabels } from '../content/concepts'
 
+const STORAGE_KEY = 'kontango.profile'
+
+function loadInitialProfile(): ConceptProfile | 'all' {
+  if (typeof window === 'undefined') return 'all'
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored === 'newcomer' || stored === 'business' || stored === 'operator') return stored
+  return 'all'
+}
+
 export function Concepts() {
-  const [profile, setProfile] = useState<ConceptProfile | 'all'>('all')
+  const [profile, setProfile] = useState<ConceptProfile | 'all'>(loadInitialProfile)
   const [isMobile, setIsMobile] = useState(false)
 
   useEffect(() => {
@@ -15,14 +24,22 @@ export function Concepts() {
     return () => window.removeEventListener('resize', checkMobile)
   }, [])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (profile === 'all') window.localStorage.removeItem(STORAGE_KEY)
+    else window.localStorage.setItem(STORAGE_KEY, profile)
+  }, [profile])
+
   const visible = profile === 'all'
     ? concepts
     : concepts.filter(c => c.profiles.includes(profile))
 
-  // Newcomers default to short. Operators default to full.
+  // Profile choice determines default variant.
   const linkFor = (slug: string) => {
-    if (profile === 'newcomer') return `/concepts/${slug}?v=short`
-    return `/concepts/${slug}`
+    if (profile === 'all') return `/concepts/${slug}`
+    const variant = profileLabels[profile].defaultVariant
+    if (variant === 'medium') return `/concepts/${slug}`
+    return `/concepts/${slug}?v=${variant}`
   }
 
   const heroStyle: CSSProperties = {
@@ -37,13 +54,13 @@ export function Concepts() {
     gap: theme.spacing.md,
     maxWidth: '880px',
     margin: '0 auto',
-    marginBottom: theme.spacing.xxl,
+    marginBottom: theme.spacing.xl,
   }
 
-  const profileCard = (active: boolean): CSSProperties => ({
+  const profileCard = (active: boolean, color: string): CSSProperties => ({
     padding: theme.spacing.lg,
-    background: active ? 'rgba(74, 158, 255, 0.08)' : theme.colors.surface,
-    border: `1px solid ${active ? theme.colors.primary : theme.colors.border}`,
+    background: active ? `${color}14` : theme.colors.surface, // 14 = ~8% alpha hex
+    border: `2px solid ${active ? color : theme.colors.border}`,
     borderRadius: theme.borderRadius.lg,
     cursor: 'pointer',
     textAlign: 'left',
@@ -51,6 +68,7 @@ export function Concepts() {
     color: theme.colors.textPrimary,
     fontFamily: 'inherit',
     width: '100%',
+    position: 'relative',
   })
 
   const conceptGrid: CSSProperties = {
@@ -71,6 +89,8 @@ export function Concepts() {
     transition: 'all 0.15s ease',
   }
 
+  const activeProfileMeta = profile !== 'all' ? profileLabels[profile] : undefined
+
   return (
     <Container size="lg">
       <section style={heroStyle}>
@@ -90,11 +110,11 @@ export function Concepts() {
           margin: '0 auto',
           lineHeight: 1.6,
         }}>
-          Eight short pages that explain Kontango in plain language. Pick the angle that fits — we'll show you the version that makes sense for you.
+          Eight short pages that explain Kontango in plain language. Pick the version that fits — quick, standard, or deep.
         </p>
       </section>
 
-      <section style={{ marginBottom: theme.spacing.xl }}>
+      <section>
         <div style={{
           fontSize: theme.fontSize.sm,
           color: theme.colors.textMuted,
@@ -106,50 +126,78 @@ export function Concepts() {
           Choose your view
         </div>
         <div style={profileGrid}>
-          {(['newcomer', 'business', 'operator'] as ConceptProfile[]).map(p => (
-            <button
-              key={p}
-              style={profileCard(profile === p)}
-              onClick={() => setProfile(profile === p ? 'all' : p)}
-            >
-              <div style={{
-                fontSize: theme.fontSize.base,
-                fontWeight: theme.fontWeight.bold,
-                color: profile === p ? theme.colors.primary : theme.colors.textPrimary,
-                marginBottom: theme.spacing.xs,
-              }}>
-                {profileLabels[p].name}
-              </div>
-              <div style={{
-                fontSize: theme.fontSize.sm,
-                color: theme.colors.textSecondary,
-                lineHeight: 1.5,
-              }}>
-                {profileLabels[p].tagline}
-              </div>
-            </button>
-          ))}
+          {(['newcomer', 'business', 'operator'] as ConceptProfile[]).map(p => {
+            const meta = profileLabels[p]
+            const active = profile === p
+            return (
+              <button
+                key={p}
+                style={profileCard(active, meta.tierColor)}
+                onClick={() => setProfile(active ? 'all' : p)}
+                aria-pressed={active}
+              >
+                <div style={{
+                  display: 'inline-block',
+                  padding: `2px ${theme.spacing.sm}`,
+                  background: meta.tierColor,
+                  color: '#0a0a0f',
+                  fontSize: theme.fontSize.xs,
+                  fontWeight: theme.fontWeight.bold,
+                  borderRadius: theme.borderRadius.full,
+                  marginBottom: theme.spacing.sm,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                }}>
+                  {meta.defaultVariant === 'short' ? 'Quick' : meta.defaultVariant === 'medium' ? 'Standard' : 'Deep'}
+                </div>
+                <div style={{
+                  fontSize: theme.fontSize.lg,
+                  fontWeight: theme.fontWeight.bold,
+                  color: active ? meta.tierColor : theme.colors.textPrimary,
+                  marginBottom: theme.spacing.xs,
+                }}>
+                  {meta.name}
+                </div>
+                <div style={{
+                  fontSize: theme.fontSize.sm,
+                  color: theme.colors.textSecondary,
+                  lineHeight: 1.5,
+                }}>
+                  {meta.tagline}
+                </div>
+              </button>
+            )
+          })}
         </div>
-        {profile !== 'all' && (
-          <div style={{ textAlign: 'center', fontSize: theme.fontSize.sm, color: theme.colors.textMuted }}>
-            Showing concepts most useful for: <strong style={{ color: theme.colors.textSecondary }}>{profileLabels[profile].name}</strong>
-            {' · '}
-            <button
-              style={{
-                background: 'none',
-                border: 'none',
-                color: theme.colors.primary,
-                cursor: 'pointer',
-                fontSize: 'inherit',
-                padding: 0,
-                fontFamily: 'inherit',
-              }}
-              onClick={() => setProfile('all')}
-            >
-              Show all
-            </button>
-          </div>
-        )}
+        <div style={{
+          textAlign: 'center',
+          fontSize: theme.fontSize.sm,
+          color: theme.colors.textMuted,
+          marginBottom: theme.spacing.xl,
+        }}>
+          {activeProfileMeta ? (
+            <>
+              Cards link to the <strong style={{ color: activeProfileMeta.tierColor }}>{activeProfileMeta.defaultVariant === 'short' ? 'Quick' : activeProfileMeta.defaultVariant === 'medium' ? 'Standard' : 'Deep'}</strong> version.
+              {' '}
+              <button
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: theme.colors.primary,
+                  cursor: 'pointer',
+                  fontSize: 'inherit',
+                  padding: 0,
+                  fontFamily: 'inherit',
+                }}
+                onClick={() => setProfile('all')}
+              >
+                Show all concepts
+              </button>
+            </>
+          ) : (
+            <>You can change versions on any page.</>
+          )}
+        </div>
       </section>
 
       <section style={conceptGrid}>
@@ -181,7 +229,9 @@ export function Concepts() {
               {c.description}
             </p>
             <div style={{ fontSize: theme.fontSize.xs, color: theme.colors.textMuted }}>
-              {profile === 'newcomer' ? 'Quick version · ~1 min' : `⏱️ ${c.timeEstimate}`}
+              {profile === 'newcomer' ? 'Quick · ~1 min' :
+               profile === 'operator' ? `Deep · ~${parseInt(c.timeEstimate) * 2} min` :
+               `⏱️ ${c.timeEstimate}`}
             </div>
           </Link>
         ))}


### PR DESCRIPTION
## Summary

Adds three reading depths to each concept and wires them to the profile selector. The docs repo now ships short and long variants alongside the existing medium versions.

## What changed

**`src/content/concepts.ts`**
- New \`ConceptVariant = 'short' | 'medium' | 'long'\` type
- \`profileLabels\` gains \`defaultVariant\` and \`tierColor\` so each profile maps to its tier
- \`fileSuffix(variant)\` and \`variantLabels\` helpers for URL routing and display

**\`src/pages/ConceptArticle.tsx\`**
- Three-pill toggle (Quick / Standard / Deep), tier-colored when active
- URL param \`?v=short\` or \`?v=long\`; bare URL = Standard
- Falls back to Standard if a tier doesn't exist for that concept
- Prev/next nav preserves the current variant

**\`src/pages/Concepts.tsx\`**
- Each profile card shows its default variant as a tier pill
- Selecting a profile changes link targets and persists to localStorage
- Card meta (time estimate) reflects the current variant

## Tier color mapping

| Profile | Default variant | Tier color |
|---------|-----------------|------------|
| New here | Quick | \`theme.colors.basic\` (#51cf66) |
| Decision maker | Standard | \`theme.colors.intermediate\` (#ffd43b) |
| Running it | Deep | \`theme.colors.enterprise\` (#4a9eff) |

## Test plan

- [ ] \`/concepts\` renders three profile cards with tier-colored badges
- [ ] Picking "New here" → cards link to \`?v=short\`
- [ ] Picking "Running it" → cards link to \`?v=long\`
- [ ] Article page tier pills swap content on click
- [ ] Profile choice persists to localStorage and survives reload
- [ ] Prev/next nav preserves the active variant in URL
- [ ] Build passes (verified locally — 1.51s, 187 KB gzipped)

Closes #2